### PR TITLE
Improved some parts of publisher and consumer

### DIFF
--- a/bunny_storm/publisher.py
+++ b/bunny_storm/publisher.py
@@ -90,7 +90,8 @@ class Publisher:
                                mandatory: bool = True,
                                immediate: bool = False,
                                timeout: Union[int, float, None] = None) -> Union[Exception, None]:
-        self.logger.info(f"Publishing message. exchange: {exchange}; routing_key: {routing_key}; message: {message}")
+        self.logger.info(
+            f"Publishing message. exchange: {exchange}; routing_key: {routing_key}; message: {message.body[:100]}")
         try:
             result = await exchange.publish(
                 message=message,


### PR DESCRIPTION
- Made the publish message log limited to 100 chars.
- added the option to publish to the default exchange using `AsyncAdapter.publish`.
- Added `exclusive` parameter to the `receive` and `consume` methods in order to control the exclusivity of the consumption when not using rpc directly